### PR TITLE
Fixing branch

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.formatting.provider": "black"
+}

--- a/bla.py
+++ b/bla.py
@@ -27,18 +27,40 @@ def decToBin(decimal_number):
 
 def mac2linklocal():
     mac = input("Please Enter MAC-Address: ")
+    
     first_hex_block = mac[0] + mac[1]
+    
     second_nibble_in_dec = int(first_hex_block[1], 16)
+    
     second_nibble_in_bin = decToBin(second_nibble_in_dec)[-4:]
+    
     new_second_nibble_in_bin = bitFlipper(second_nibble_in_bin)
     
+    second_nibble_back2hex = hex(int(new_second_nibble_in_bin,2)).lower()
+    second_nibble_back2hex = second_nibble_back2hex[-1]
+    
+    if mac[1] != second_nibble_back2hex:
+        new_character = str(second_nibble_back2hex)
+        mac = mac[:1] + new_character + mac[2:]
+
+    if len(mac) == 17:
+        position = 8
+        new_character = "-ff-fe-"
+        mac = mac[:position] + new_character + mac[position+1:]
+
+    counter = 5
+    for i in range(len(mac)):
+        if i == counter:
+            position = counter
+            new_character = ":"
+            mac = mac[:position] + new_character + mac[position+1:]
+            counter += 6
+    
+    mac = mac.replace("-", "")
+
+    return f"IPv6 Link-Local Address: " " fe80::"+mac.lower()
    
-    
-    # second_4_bits = int(mac[1], 16)
-    # print(second_4_bits)
-    # second_bin = decToBin(second_4_bits)
-    # print(second_bin)
-    
+   
     
     
 print("Please Select an Option: ")

--- a/bla.py
+++ b/bla.py
@@ -1,3 +1,13 @@
+def bitFlipper(binary_string):
+    if binary_string[-2] == "0":
+        flip = "1"
+        binary_string = binary_string[:-2] + flip + binary_string[-1]
+    else:
+        flip = "0"
+        binary_string = binary_string[:-2] + flip + binary_string[-1]
+    
+    return binary_string
+
 
 def decToBin(decimal_number):
     bin_format = ""
@@ -20,6 +30,7 @@ def mac2linklocal():
     first_hex_block = mac[0] + mac[1]
     second_nibble_in_dec = int(first_hex_block[1], 16)
     second_nibble_in_bin = decToBin(second_nibble_in_dec)[-4:]
+    new_second_nibble_in_bin = bitFlipper(second_nibble_in_bin)
     
    
     

--- a/bla.py
+++ b/bla.py
@@ -1,0 +1,40 @@
+
+def decToBin(decimal_number):
+    bin_format = ""
+    
+    if decimal_number <= 0:
+        bin_format += "0000"
+    elif decimal_number == 1:
+        bin_format += "0001"
+    else:
+        bin_format += str(decToBin(decimal_number // 2))
+        rest = decimal_number % 2
+        bin_format += str(rest)
+    
+    
+    return bin_format
+
+
+def mac2linklocal():
+    mac = input("Please Enter MAC-Address: ")
+    first_hex_block = mac[0] + mac[1]
+    second_nibble_in_dec = int(first_hex_block[1], 16)
+    second_nibble_in_bin = decToBin(second_nibble_in_dec)[-4:]
+    
+   
+    
+    # second_4_bits = int(mac[1], 16)
+    # print(second_4_bits)
+    # second_bin = decToBin(second_4_bits)
+    # print(second_bin)
+    
+    
+    
+print("Please Select an Option: ")
+print("1. MAC-Address to IPv6 Link-Local")
+print("2. IPv6 Link-Local to MAC-Address")
+
+select = input("Select: ")
+
+if select == "1":
+    print(mac2linklocal())    

--- a/mac2linklocal.py
+++ b/mac2linklocal.py
@@ -1,48 +1,51 @@
+def bitFlipper(binary_string):
+    if binary_string[-2] == "0":
+        flip = "1"
+        binary_string = binary_string[:-2] + flip + binary_string[-1]
+    else:
+        flip = "0"
+        binary_string = binary_string[:-2] + flip + binary_string[-1]
+    
+    return binary_string
+
+
+def decToBin(decimal_number):
+    bin_format = ""
+    
+    if decimal_number <= 0:
+        bin_format += "0000"
+    elif decimal_number == 1:
+        bin_format += "0001"
+    else:
+        bin_format += str(decToBin(decimal_number // 2))
+        rest = decimal_number % 2
+        bin_format += str(rest)
+    
+    
+    return bin_format
+
+
 def mac2linklocal():
     mac = input("Please Enter MAC-Address: ")
-    erste_octett = mac[0] + mac[1]
-    #print(erste_octett)
-    second_4_bits = int(mac[1], 16)
-    #print(second_4_bits)
-    second_bin = bin(second_4_bits)
-    #print(second_bin)
-
-    if len(second_bin) >= 3:
-        if second_bin[-1] == "0":
-            position = -2
-            new_character = '0'
-            second_bin = second_bin[:position] + new_character + second_bin[position+1:]
-
-        if second_bin[-1] == "1":
-            position = -2
-            new_character = '1'
-            second_bin = second_bin[:position] + new_character + second_bin[position+1]
-    else:
-
-        if second_bin[-2] == "0":
-            position = -2
-            new_character = '1'
-            second_bin = second_bin[:position] + new_character + second_bin[position+1:]
-            #print(second_bin)
-
-        if second_bin[-2] == "1":
-            position = -2
-            new_character = '0'
-            second_bin = second_bin[:position] + new_character + second_bin[position+1:]
-            #print(second_bin)
-
-    second_bin = int(second_bin, 2)
-    second_bin = hex(second_bin).upper()
-    second_4_bits = second_bin[2:]
-    #print(second_4_bits)
-    if mac[1] != second_4_bits:
-        position = 1
-        new_character = str(second_4_bits)
-        mac = mac[:position] + new_character + mac[position+1:]
+    
+    first_hex_block = mac[0] + mac[1]
+    
+    second_nibble_in_dec = int(first_hex_block[1], 16)
+    
+    second_nibble_in_bin = decToBin(second_nibble_in_dec)[-4:]
+    
+    new_second_nibble_in_bin = bitFlipper(second_nibble_in_bin)
+    
+    second_nibble_back2hex = hex(int(new_second_nibble_in_bin,2)).lower()
+    second_nibble_back2hex = second_nibble_back2hex[-1]
+    
+    if mac[1] != second_nibble_back2hex:
+        new_character = str(second_nibble_back2hex)
+        mac = mac[:1] + new_character + mac[2:]
 
     if len(mac) == 17:
         position = 8
-        new_character = "-FF-FE-"
+        new_character = "-ff-fe-"
         mac = mac[:position] + new_character + mac[position+1:]
 
     counter = 5
@@ -52,7 +55,7 @@ def mac2linklocal():
             new_character = ":"
             mac = mac[:position] + new_character + mac[position+1:]
             counter += 6
-    #print(mac)
+    
     mac = mac.replace("-", "")
 
     return f"IPv6 Link-Local Address: " " fe80::"+mac.lower()


### PR DESCRIPTION
In this merge the mac2linklocal function went through major fixes, as the following _three example_s trashed the old function: 

_00-B0-D0-63-C2-26
11-22-33-44-55-66
52-74-F2-B1-A8-7F_

and thats because in the old mac2linkfunction it was relying on the built in function **bin()** to convert from decimals to binary.

Major Changes:

- self written function **dectoBin()** to convert from decimal to binary returning a string of 4 bits
- **new bitFlipper()** function is written to manipulate the most significant bit from that strin from the previous function


with both functions fixed old issues and the rest of building the IPv6 address remains the same.

**mac2linklocal()** seems to work fine and passed the previous three examples 